### PR TITLE
Fixed RenderPerf parser (FPS only)

### DIFF
--- a/src/main/java/com/jetbrains/JBRperf/RenderLogReader.java
+++ b/src/main/java/com/jetbrains/JBRperf/RenderLogReader.java
@@ -16,13 +16,32 @@ public class RenderLogReader extends OneScoreLogReader {
         int i = 0;
         while (input.hasNextLine()) {
             String line = input.nextLine();
-            if (line.startsWith("#") || !line.contains(":") || !line.contains("FPS")) continue;
 
+             // System.out.println("Line: " + line);
+
+            if (line.startsWith("#") || line.startsWith("[")
+                    || !line.contains(":")) continue;
+
+            // Check legend (24.02):
+            if (line.startsWith("Test Name")) {
+                // System.out.println("LINE:" + line);
+                if (line.contains("Median(TimeMs)")) {
+                    System.out.println("Unsupported Time unit (expected FPS results) !");
+                    return;
+                }
+                continue;
+            }
+
+            // only supports single FPS score:
+            if (!line.contains("FPS")) continue;
             String[] scores = line.split(":");
             if (scores.length == 0) break;
 
             String scoreName = scores[0].trim();
-            metrics.add(i++, scoreName);
+            // Avoid repeated metrics:
+            if (!metrics.contains(scoreName)) {
+                metrics.add(i++, scoreName);
+            }
             values.put(scoreName, Float.valueOf(scores[1].trim().split(" ")[0].replace(",",".")));
         }
     }


### PR DESCRIPTION
Tested on following files with this Test code:
```
package com.jetbrains.JBRperf;

import java.io.File;
import java.io.FileNotFoundException;

public class Test {

    public static void main(String[] unused) {

        for (File f : new File("/Users/bourgesl/dev/JBRperf-lbo/test/").listFiles()) {
            if (!f.getName().contains("Test-")) {
                continue;
            }
            String absPath = f.getAbsolutePath();

            System.out.println("-----");
            System.out.println("Loading result: " + absPath);
            try {
                var r = new RenderLogReader();
                r.readLog(absPath);

                System.out.println("metrics: " + r.metrics);
                System.out.println("scores: " + r.getScores("test"));

            } catch (FileNotFoundException e) {
                throw new RuntimeException(e);
            } catch (RuntimeException re) {
                System.err.println("Failure:");
                re.printStackTrace();
            }
        }
    }
}

```
See [Test-Performance_Render_MacOS13-aarch64_Metal_2074.log](https://github.com/vprovodin/JBRperf/files/14790619/Test-Performance_Render_MacOS13-aarch64_Metal_2074.log)
[Test-Performance_Render_MacOS13-x86_64_Metal_419.log](https://github.com/vprovodin/JBRperf/files/14790620/Test-Performance_Render_MacOS13-x86_64_Metal_419.log)
[Test-Performance_Render_MacOS13-x86_64_Metal_782.log](https://github.com/vprovodin/JBRperf/files/14790621/Test-Performance_Render_MacOS13-x86_64_Metal_782.log)
[Test-Performance_Render_MacOS13-x86_64_Metal_1264.log](https://github.com/vprovodin/JBRperf/files/14790622/Test-Performance_Render_MacOS13-x86_64_Metal_1264.log)
